### PR TITLE
Fix `ChangeSet::last_evicted` in `read_tx_graph`

### DIFF
--- a/src/async_store.rs
+++ b/src/async_store.rs
@@ -207,7 +207,9 @@ impl Store {
             changeset.txs.insert(Arc::new(tx));
             changeset.first_seen.insert(txid, first_seen.try_into()?);
             changeset.last_seen.insert(txid, last_seen.try_into()?);
-            changeset.last_seen.insert(txid, last_evicted.try_into()?);
+            changeset
+                .last_evicted
+                .insert(txid, last_evicted.try_into()?);
         }
 
         let rows = sqlx::query("SELECT txid, vout, value, script FROM txout")


### PR DESCRIPTION
This fixes a bug where we failed to update the `last_evicted` field of `tx_graph::ChangeSet` when reading the tx graph data.