### PR TITLE
WIP: Test async wallet persister

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,14 @@ readme = "README.md"
 
 [dependencies]
 bdk_chain = { version = "0.23.3", features = ["miniscript"] }
-bdk_wallet = { version = "3.0.0", optional = true }
+bdk_wallet = { version = "3.1.0-alpha.0", optional = true }
 sqlx = { version = "0.8.6", features = ["sqlite", "runtime-tokio"] }
 
 [dev-dependencies]
 anyhow = "1"
 bdk_esplora = { version = "0.22.2", features = ["tokio"] }
 tokio = { version = "1", default-features = false, features = ["full"] }
+bdk_wallet = { version = "3.1.0-alpha.0", features = ["test-utils"] }
 
 [dev-dependencies.bdk_sqlite]
 path = "."
@@ -27,8 +28,11 @@ features = ["wallet"]
 
 [features]
 default = ["wallet"]
-wallet = ["dep:bdk_wallet"]
-
+wallet = ["bdk_wallet"]
 
 [[example]]
 name = "wallet"
+
+[patch.crates-io.bdk_wallet]
+git = "https://github.com/ValuedMammal/bdk_wallet"
+branch = "feat/persist_test_utils_async"

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -213,6 +213,7 @@ impl AsyncWalletPersister for Store {
 mod test {
     use super::*;
 
+    use bdk_wallet::persist_test_utils::*;
     use bitcoin::Network;
 
     #[tokio::test]
@@ -232,6 +233,33 @@ mod test {
             .await?;
 
         assert_eq!(count, 1, "network table should have at most 1 row");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_async_wallet_persister_network() -> anyhow::Result<()> {
+        persist_network_async::<_, Store>(async || Ok(Store::new_memory().await?))
+            .await
+            .expect("failed test persist wallet changeset");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_async_wallet_persister_keychains() -> anyhow::Result<()> {
+        persist_keychains_async::<_, Store>(async || Ok(Store::new_memory().await?))
+            .await
+            .expect("failed test persist wallet changeset");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_async_wallet_persister() -> anyhow::Result<()> {
+        persist_wallet_changeset_async::<_, Store>(async || Ok(Store::new_memory().await?))
+            .await
+            .expect("failed test persist wallet changeset");
 
         Ok(())
     }


### PR DESCRIPTION
## Description

Adds a test `test_async_wallet_persister`.

In draft state as it currently depends on a fork of `bdk_wallet` [ValuedMammal:feat/persist_test_utils_async](https://github.com/ValuedMammal/bdk_wallet/tree/feat/persist_test_utils_async).

fix #5 