### PR TITLE
fix: Avoid inserting block rows of duplicate heights

### DIFF
--- a/src/async_store.rs
+++ b/src/async_store.rs
@@ -314,3 +314,70 @@ impl Store {
         Ok(changeset)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use bitcoin::hashes::Hash;
+
+    #[tokio::test]
+    async fn block_table_height_is_unique() -> anyhow::Result<()> {
+        let mut cs = local_chain::ChangeSet::default();
+        cs.blocks.insert(0, Some(Hash::hash(b"0")));
+        cs.blocks.insert(1, Some(Hash::hash(b"1")));
+
+        let store = Store::new_memory().await?;
+        store.migrate().await?;
+        store
+            .write_local_chain(&cs)
+            .await
+            .expect("failed to write `local_chain`");
+
+        // Trying to replace the value of existing height should be ignored.
+        cs.blocks.insert(1, Some(Hash::hash(b"1a")));
+
+        store
+            .write_local_chain(&cs)
+            .await
+            .expect("failed to write `local_chain`");
+
+        let rows = sqlx::query("SELECT height, hash FROM block WHERE height = 1")
+            .fetch_all(&store.pool)
+            .await?;
+
+        assert_eq!(rows.len(), 1, "Expected 1 block row");
+
+        let row = rows.first().unwrap();
+        let row_hash: String = row.get("hash");
+        let expected_hash: BlockHash = Hash::hash(b"1");
+        assert_eq!(row_hash, expected_hash.to_string());
+
+        // Delete row 1 and insert hash "1a" again.
+        let mut cs = local_chain::ChangeSet::default();
+        cs.blocks.insert(1, None);
+        store
+            .write_local_chain(&cs)
+            .await
+            .expect("failed to write `local_chain`");
+
+        cs.blocks.insert(1, Some(Hash::hash(b"1a")));
+        store
+            .write_local_chain(&cs)
+            .await
+            .expect("failed to write `local_chain`");
+
+        let rows = sqlx::query("SELECT height, hash FROM block WHERE height = 1")
+            .fetch_all(&store.pool)
+            .await?;
+
+        // Row hash should change to "1a".
+        assert_eq!(rows.len(), 1, "Expected 1 block row");
+        let row = rows.first().unwrap();
+        let row_hash: String = row.get("hash");
+        let expected_hash: BlockHash = Hash::hash(b"1a");
+        assert_eq!(row_hash, expected_hash.to_string());
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is a hotfix intended to address #8. The approach is to have an additional `SELECT` query to check for existing rows of a given height before executing the actual `INSERT` statement. A better long-term solution which may be done as a follow-up is to enforce a unique block height per row directly at the schema level.