### PR TITLE
WIP: Update `bdk_wallet` to 3.0.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+### Description
+
+<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
+
+### Notes to the reviewers
+
+<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
+of the PR were done in a specific way -->
+
+### Changelog notice
+
+<!-- Notice the release manager should include in the release tag message changelog -->
+<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-bdk_chain = { version = "0.23.2", features = ["miniscript"] }
+bdk_chain = { version = "0.23.3", features = ["miniscript"] }
 bdk_wallet = { version = "2.3.0", optional = true }
 sqlx = { version = "0.8.6", features = ["sqlite", "runtime-tokio"] }
 
 [dev-dependencies]
 anyhow = "1"
-bdk_esplora = { version = "0.22.1", features = ["tokio"] }
+bdk_esplora = { version = "0.22.2", features = ["tokio"] }
 tokio = { version = "1", default-features = false, features = ["full"] }
 
 [dev-dependencies.bdk_sqlite]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 bdk_chain = { version = "0.23.3", features = ["miniscript"] }
-bdk_wallet = { version = "2.3.0", optional = true }
+bdk_wallet = { version = "3.0.0", optional = true }
 sqlx = { version = "0.8.6", features = ["sqlite", "runtime-tokio"] }
 
 [dev-dependencies]

--- a/migrations/0003_schema.up.sql
+++ b/migrations/0003_schema.up.sql
@@ -1,0 +1,7 @@
+-- Add locked outpoints table
+
+CREATE TABLE IF NOT EXISTS locked_outpoint(
+    txid TEXT NOT NULL,
+    vout INTEGER NOT NULL,
+    PRIMARY KEY(txid, vout)
+);

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -4,8 +4,9 @@ use std::{collections::BTreeMap, pin::Pin, str::FromStr};
 
 use bdk_chain::bitcoin;
 use bdk_chain::miniscript;
-use bdk_wallet::{AsyncWalletPersister, ChangeSet, KeychainKind};
+use bdk_wallet::{AsyncWalletPersister, ChangeSet, KeychainKind, locked_outpoints};
 use bitcoin::Network;
+use bitcoin::OutPoint;
 use miniscript::descriptor::{Descriptor, DescriptorPublicKey};
 use sqlx::Row;
 
@@ -31,6 +32,8 @@ impl Store {
         self.write_local_chain(&changeset.local_chain).await?;
         self.write_tx_graph(&changeset.tx_graph).await?;
         self.write_keychain_txout(&changeset.indexer).await?;
+        self.write_locked_outpoints(&changeset.locked_outpoints)
+            .await?;
 
         Ok(())
     }
@@ -76,6 +79,7 @@ impl Store {
         let tx_graph = self.read_tx_graph().await?;
         let local_chain = self.read_local_chain().await?;
         let indexer = self.read_keychain_txout().await?;
+        let locked_outpoints = self.read_locked_outpoints().await?;
 
         Ok(ChangeSet {
             network,
@@ -84,6 +88,7 @@ impl Store {
             tx_graph,
             local_chain,
             indexer,
+            locked_outpoints,
         })
     }
 
@@ -125,6 +130,49 @@ impl Store {
         }
 
         Ok(descriptors)
+    }
+
+    /// Write locked outpoints.
+    pub async fn write_locked_outpoints(
+        &self,
+        locked_outpoints: &locked_outpoints::ChangeSet,
+    ) -> Result<(), Error> {
+        for (&outpoint, &is_locked) in &locked_outpoints.outpoints {
+            let OutPoint { txid, vout } = outpoint;
+            if is_locked {
+                sqlx::query("INSERT OR IGNORE INTO locked_outpoint(txid, vout) VALUES($1, $2)")
+                    .bind(txid.to_string())
+                    .bind(vout)
+                    .execute(&self.pool)
+                    .await?;
+            } else {
+                sqlx::query("DELETE FROM locked_outpoint WHERE txid = $1 AND vout = $2")
+                    .bind(txid.to_string())
+                    .bind(vout)
+                    .execute(&self.pool)
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Read locked outpoints.
+    pub async fn read_locked_outpoints(&self) -> Result<locked_outpoints::ChangeSet, Error> {
+        let mut changeset = locked_outpoints::ChangeSet::default();
+
+        let rows = sqlx::query("SELECT txid, vout FROM locked_outpoint")
+            .fetch_all(&self.pool)
+            .await?;
+        for row in rows {
+            let txid: String = row.get("txid");
+            let txid: bitcoin::Txid = txid.parse()?;
+            let vout: u32 = row.get("vout");
+            let outpoint = OutPoint { txid, vout };
+            changeset.outpoints.insert(outpoint, true);
+        }
+
+        Ok(changeset)
     }
 }
 


### PR DESCRIPTION
### Description

Updates `bdk_wallet` from 2.3.0 to 3.0.0, along with companion bumps to `bdk_chain` (0.23.2 → 0.23.3) and `bdk_esplora` dev dependency (0.22.1 → 0.22.2).

`bdk_wallet` 3.0.0 adds a `locked_outpoints` field to `ChangeSet`, representing the persisted state of UTXO locks. This PR adds support for reading and writing that state:

- Adds migration `0003_schema.up.sql` which creates the `locked_outpoint(txid, vout)` table
- Adds `write_locked_outpoints` / `read_locked_outpoints` on `Store`, wired into the existing `write_changeset` / `read_changeset` methods

### Notes to the reviewers

The `write_locked_outpoints` implementation uses the `locked_outpoints::ChangeSet` semantics directly: a `true` value inserts the row (`INSERT OR IGNORE`), and a `false` value deletes it. On read, all rows in the table are returned as locked (`true`) (an absent row means unlocked).

### Changelog notice

### Added
- Migration `0003_schema.up.sql`: add `locked_outpoint` table for persisting UTXO lock state

### Changed
- Bump `bdk_chain` 0.23.2 → 0.23.3
- Bump `bdk_wallet` 2.3.0 → 3.0.0
- Bump `bdk_esplora` (dev) 0.22.1 → 0.22.2