### PR TITLE
fix(schema): Add singleton constraint to the network table

### DIFF
--- a/migrations/0004_schema.up.sql
+++ b/migrations/0004_schema.up.sql
@@ -1,0 +1,21 @@
+-- Recreate the network table with an `id` column that is both the PRIMARY KEY and
+-- always checked to be 0. This makes it structurally impossible for more
+-- than one row to exist.
+
+-- ********************************************** --
+-- Add singleton constraint to the network table. --
+-- ********************************************** --
+
+CREATE TABLE IF NOT EXISTS network_new(
+    id      INTEGER NOT NULL DEFAULT 0 CHECK(id = 0),
+    network TEXT    NOT NULL,
+    PRIMARY KEY(id)
+);
+
+-- Copy at most one existing row, pinning id to 0.
+INSERT OR IGNORE INTO network_new(id, network)
+SELECT 0, network FROM network LIMIT 1;
+
+DROP TABLE network;
+
+ALTER TABLE network_new RENAME TO network;

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -42,7 +42,7 @@ impl Store {
 
     /// Write network.
     pub async fn write_network(conn: &mut SqliteConnection, network: Network) -> Result<(), Error> {
-        sqlx::query("INSERT OR IGNORE INTO network(network) VALUES($1)")
+        sqlx::query("INSERT OR IGNORE INTO network(id, network) VALUES(0, $1)")
             .bind(network.to_string())
             .execute(&mut *conn)
             .await?;
@@ -206,5 +206,33 @@ impl AsyncWalletPersister for Store {
         Self: 'a,
     {
         Box::pin(async { persister.write_changeset(changeset).await })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use bitcoin::Network;
+
+    #[tokio::test]
+    async fn network_table_has_at_most_one_row() -> anyhow::Result<()> {
+        let store = Store::new_memory().await?;
+        store.migrate().await?;
+
+        {
+            let mut txn = store.pool.begin().await?;
+            Store::write_network(&mut txn, Network::Bitcoin).await?;
+            Store::write_network(&mut txn, Network::Bitcoin).await?;
+            txn.commit().await?;
+        }
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM network")
+            .fetch_one(&store.pool)
+            .await?;
+
+        assert_eq!(count, 1, "network table should have at most 1 row");
+
+        Ok(())
     }
 }


### PR DESCRIPTION
### Description

The `network` table should hold at most one row (the network the wallet was initialized with). Previously the table had no unique constraint, so every call to `INSERT OR IGNORE INTO network` would insert a fresh row, accumulating duplicates.

Add migration `0004_schema.up.sql` that recreates the table with an `id INTEGER NOT NULL DEFAULT 0 CHECK(id = 0) PRIMARY KEY` column. The `CHECK` combined with the primary key makes it structurally impossible for more than one row to exist. Any pre-existing rows are migrated by copying at most one, pinning `id = 0`.

`write_network` is updated to always supply `id = 0` explicitly. This is necessary because SQLite's `INTEGER PRIMARY KEY` alias auto-increments when the column is omitted, which would fail the `CHECK` and cause `OR IGNORE` to silently drop every write.

A regression test (`network_table_has_at_most_one_row`) is included that calls `write_network` twice and asserts exactly one row exists.

### Notes to the reviewers

The `DEFAULT 0` on the `id` column is cosmetic — the insert always supplies the literal `0`, but it signals intent clearly to anyone reading the schema.

### Changelog notice

Fixed

- schema: `network` table now enforces a singleton constraint in `0004_schema.up.sql`
